### PR TITLE
Potential fix for code scanning alert no. 211: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,8 @@
 name: Docs
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/Ajimaru/LM-Studio/security/code-scanning/211](https://github.com/Ajimaru/LM-Studio/security/code-scanning/211)

In general, the fix is to explicitly define a `permissions` block limiting `GITHUB_TOKEN` to the minimal scope required. For this docs-quality job, the steps only need to read repository contents, so `contents: read` is sufficient; no write permissions or other scopes (issues, pull-requests, etc.) are necessary.

The best way to fix this without changing existing behavior is to add a `permissions` block at the workflow root, just under the `name:` (before `on:`). That way, all jobs in this workflow—currently only `docs-quality`—inherit the restricted permissions. Concretely, in `.github/workflows/docs.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Docs`) and line 3 (`on:`). No new imports or additional methods are needed, and no steps need to be modified; the `GITHUB_TOKEN` environment variable will continue to work but with reduced privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions for security best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->