### PR TITLE
Potential fix for code scanning alert no. 210: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Ajimaru/LM-Studio/security/code-scanning/210](https://github.com/Ajimaru/LM-Studio/security/code-scanning/210)

To fix the problem, explicitly declare restricted `GITHUB_TOKEN` permissions in the workflow. Since this CI job only checks out code and runs local syntax checks, it requires only read access to repository contents; it does not need to write to the repo, issues, or pull requests.

The best way to fix this without changing existing functionality is to add a `permissions` block at the root of `.github/workflows/ci.yml`, right after the `name: CI` line. This will apply to all jobs in the workflow (there is only `validate`), and set `contents: read`, which matches the minimal recommendation and is sufficient for `actions/checkout` to function. No imports or other code changes are needed.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between line 1 (`name: CI`) and line 3 (`on:`), keeping indentation consistent.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions configuration for enhanced security practices.

**Note:** This release contains infrastructure updates only. No user-facing changes or new features are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->